### PR TITLE
Use environtment variables file

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -1,10 +1,11 @@
+require('dotenv').config()
 const mongoose = require('mongoose');
-const config = require('config');
-const db = config.get('mongoURI');
-
+const db = {
+    mongoURI: process.env.MONGO_URI || 'localhost',
+};
 const connectDB = async() => {
     try{
-        await mongoose.connect(db, {
+        await mongoose.connect(db.mongoURI, {
             useNewUrlParser: true
         });
         console.log('MongoDB Cloud Connected...');

--- a/config/default.json
+++ b/config/default.json
@@ -1,3 +1,0 @@
-{
-    "mongoURI": "mongodb+srv://Bo:Zb951208@chirper-2htxl.mongodb.net/test?retryWrites=true&w=majority"
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -621,6 +621,11 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
+      "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -962,7 +967,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -980,11 +986,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -997,15 +1005,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1108,7 +1119,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1118,6 +1130,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1130,17 +1143,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1157,6 +1173,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1229,7 +1246,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1239,6 +1257,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1314,7 +1333,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1344,6 +1364,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1361,6 +1382,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1399,11 +1421,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "body-parser": "^1.19.0",
     "config": "^3.1.0",
     "cors": "^2.8.5",
+    "dotenv": "^8.0.0",
     "express": "^4.17.1",
     "mongoose": "^5.6.0",
     "nodemon": "^1.19.1",

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,2 @@
+API_PORT=5000
+MONGO_URI=mongodb://secretsecretsecretsecretsecretsecretsecret

--- a/server.js
+++ b/server.js
@@ -70,6 +70,6 @@ app.use(cors());
 app.use('/', router);
 
 
-const PORT = process.env.PORT || 5000;
+const API_PORT = process.env.API_PORT || 5000;
 
-app.listen(PORT, () => console.log('Server is running!'));
+app.listen(API_PORT, () => console.log(`Server is running on port ${ API_PORT }!`));

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const express = require('express');
 const mongoose = require('mongoose');
 const request = require('request');


### PR DESCRIPTION
### A comment on security and abstracting your environment-specific settings

#### The Situation

You're currently committing a piece of sensitive information (your db access credentials) to be tracked by git. These kinds of things should not be tracked in version control, as they are available for the public to see! The common method for working with secrets required by your application is to have all of these things in a _secret_ untracked file, named `.env`--named because it stores "environment-specific variables"--then import them at runtime.

#### The Solution

I added a few small changes you should examine to understand fully. They're simple, but strange if you've never seen them before.

The `dotenv` module (https://www.npmjs.com/package/dotenv) was installed, which allows it to use variables defined in that `.env` file.

The db URI was moved into that `.env` file, along with an API_ PORT variable. Your application actually already checks for this variable when it sets the API port. The line

```
const API_PORT = process.env.API_PORT || 5000;
```

in your code uses the environment variable API_PORT if it is set (in `.env` in our case). Otherwise, the fallback port is 5000.

#### Homework :)

Examine the changes in the commits I made to accomplish this, and we can discuss it in more detail next week. When you feel good about them, approve the pull request. Better yet, implement them on your own. Whatever you feel would be best to grasp this concept is perfectly fine!